### PR TITLE
Use soul for "\code"-box to allow multiline text

### DIFF
--- a/examples/listing.tex
+++ b/examples/listing.tex
@@ -2,6 +2,10 @@
 
 This property can be accessed in the frontend using \code{window.location}.
 
+Long code snippet: \code{Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.}
+
+Long code snippet consting of only one word: \code{GSxEPWkSCi5uYwb7dkayqoOo1NsncRzvVpGxJbYv2BGSxEPWkSCi5uYwb7dkayqoOo1NsncRzvVpGxJbYv2BGSxEPWkSCi5uYwb7dkayqoOo1NsncRzvVpGxJbYv2B}
+
 \beginListing{Java}{Application}{example-lst-1}
 package de.nak.template;
 

--- a/settings/asset/codestyle.tex
+++ b/settings/asset/codestyle.tex
@@ -12,14 +12,14 @@
 % "\code"-Box
 \usepackage{soul}
 
-\newcommand{\ctext}[3][RGB]{%
+\newcommand{\ctext}[2]{%
   \begingroup
-  \definecolor{hlcolor}{#1}{#2}\sethlcolor{hlcolor}%
-  \hl{#3}%
+  \sethlcolor{#1}%
+  \hl{#2}%
   \endgroup
 }
 
-\newcommand{\code}[1]{\ctext[RGB]{240,240,240}{#1}}
+\newcommand{\code}[1]{\ctext{codebackgroundcolor}{#1}}
 
 % language definition: Java (example)
 \lstdefinestyle{Java}{

--- a/settings/asset/codestyle.tex
+++ b/settings/asset/codestyle.tex
@@ -9,7 +9,17 @@
 \renewcommand*{\lstlistingname}{Code}
 \renewcommand*{\lstlistlistingname}{Codeverzeichnis}
 
-\newcommand{\code}[1]{\colorbox{codebackgroundcolor}{#1}}
+% "\code"-Box
+\usepackage{soul}
+
+\newcommand{\ctext}[3][RGB]{%
+  \begingroup
+  \definecolor{hlcolor}{#1}{#2}\sethlcolor{hlcolor}%
+  \hl{#3}%
+  \endgroup
+}
+
+\newcommand{\code}[1]{\ctext[RGB]{240,240,240}{#1}}
 
 % language definition: Java (example)
 \lstdefinestyle{Java}{

--- a/settings/asset/codestyle.tex
+++ b/settings/asset/codestyle.tex
@@ -12,14 +12,17 @@
 % "\code"-Box
 \usepackage{soul}
 
-\newcommand{\ctext}[2]{%
+\newcommand{\code}[2][codebackgroundcolor]{%
   \begingroup
   \sethlcolor{#1}%
   \hl{#2}%
   \endgroup
 }
 
-\newcommand{\code}[1]{\ctext{codebackgroundcolor}{#1}}
+\makeatletter
+% fix linebreak=true breaking literate of ')', see: https://tex.stackexchange.com/questions/69472/closing-parenthesis-as-delimiter-not-matched-when-breaklines-true
+\patchcmd{\lsthk@SelectCharTable}{\lst@ifbreaklines\lst@Def{`)}{\lst@breakProcessOther)}\fi}{}{}{}
+\makeatother
 
 % language definition: Java (example)
 \lstdefinestyle{Java}{


### PR DESCRIPTION
I didn't manage to use the preset color. Maybe one of you can do it.